### PR TITLE
Implement exporting sales data

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/DataSyncTask.java
+++ b/AndroidPOS/src/com/ricoh/pos/DataSyncTask.java
@@ -1,6 +1,8 @@
 package com.ricoh.pos;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -11,6 +13,7 @@ import android.util.Log;
 
 import com.ricoh.pos.model.IOManager;
 import com.ricoh.pos.model.ProductsManager;
+import com.ricoh.pos.model.WomanShopSalesIOManager;
 
 public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String>> {
 	final String TAG = "DataSyncTask";
@@ -18,15 +21,13 @@ public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String
 	Context context;
 	ProgressDialog progressDialog;
 	IOManager womanShopIOManager;
-	SQLiteDatabase database;
 	ProductsManager productsManager;
 
 	public DataSyncTask(Context context, DataSyncTaskCallback callback,
-			IOManager womanShopIOManager, SQLiteDatabase database) {
+			IOManager womanShopIOManager) {
 		this.callback = callback;
 		this.context = context;
 		this.womanShopIOManager = womanShopIOManager;
-		this.database = database;
 		this.productsManager = ProductsManager.getInstance();
 	}
 
@@ -54,15 +55,17 @@ public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String
 				Log.d("debug", "File not found");
 				return AsyncTaskResult.createErrorResult(R.string.sd_import_error);
 			}
-			womanShopIOManager.insertRecords(database, bufferReader);
+			womanShopIOManager.insertRecords(bufferReader);
 
-			String[] results = womanShopIOManager.searchAlldata(database);
+			String[] results = womanShopIOManager.searchAlldata();
 			for (String result : results) {
 				Log.d("debug", result);
 			}
 			productsManager.updateProducts(results);
+			WomanShopSalesIOManager.getInstance().exportCSV(context);
 		} catch (Exception e) {
 			// TODO: Should separate exception(Import, Export, at least)
+			e.printStackTrace();
 			return AsyncTaskResult.createErrorResult(R.string.sd_import_error);
 		}
 		// The argument is null because nothing to notify on success
@@ -74,7 +77,7 @@ public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String
 		Log.d(TAG, "onPostExecute");
 		if (progressDialog.isShowing()) {
 			progressDialog.dismiss();
-
+			
 			if (result.isError()) {
 				callback.onFailedSyncData(result.getResourceId());
 			} else {

--- a/AndroidPOS/src/com/ricoh/pos/SalesDatabaseHelper.java
+++ b/AndroidPOS/src/com/ricoh/pos/SalesDatabaseHelper.java
@@ -16,7 +16,7 @@ public class SalesDatabaseHelper extends SQLiteOpenHelper {
 	@Override
 	public void onCreate(SQLiteDatabase db) {
 		db.execSQL("Create Table sales_dummy (" + "_id Integer Primary Key, "
-				+ WomanShopSalesDef.PRODUCT_CODE.name() + " Text UNIQUE, "
+				+ WomanShopSalesDef.PRODUCT_CODE.name() + " Text, "
 				+ WomanShopSalesDef.PRODUCT_CATEGORY.name() + " Text, "
 				+ WomanShopSalesDef.ITEM_CATEGORY.name() + " Text, "
 				+ WomanShopSalesDef.QTY.name() + " Integer, "

--- a/AndroidPOS/src/com/ricoh/pos/model/IOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/IOManager.java
@@ -20,24 +20,20 @@ public interface IOManager {
 
 	/**
 	 * Insert all record into database.
-	 * @param database database created in app
 	 * @param bufferReader buffered records imported from csv file
 	 */
-	public abstract void insertRecords(SQLiteDatabase database,
-			BufferedReader bufferReader);
+	public abstract void insertRecords(BufferedReader bufferReader);
 
 	/**
 	 * Search all record from database.
-	 * @param database database created in app
 	 * @return search results
 	 */
-	public String[] searchAlldata(SQLiteDatabase database);
+	public String[] searchAlldata();
 	
 	/**
 	 * Search a record from database by product code
-	 * @param database database created in app
 	 * @param product code connected with a record
 	 * @return search result
 	 */
-	public abstract String searchByCode(SQLiteDatabase database, String code);
+	public abstract String searchByCode(String code);
 }

--- a/AndroidPOS/src/com/ricoh/pos/model/SalesRecordManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/SalesRecordManager.java
@@ -7,19 +7,14 @@ import java.util.Date;
 import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
-import com.ricoh.pos.data.Order;
 import com.ricoh.pos.data.SingleSalesRecord;
-import com.ricoh.pos.dummy.DummyDataBaseAccessor;
 
 public class SalesRecordManager {
 	
 	private static SalesRecordManager instance;
-	private WomanShopSalesIOManager womanShopSalesIOManager;
-	
 	public static final String SALES_DATE_KEY = "SalesDate";
 	
 	private SalesRecordManager(){
-		womanShopSalesIOManager = new WomanShopSalesIOManager();
 	}
 	
 	public static SalesRecordManager getInstance(){
@@ -34,17 +29,17 @@ public class SalesRecordManager {
 			throw new IllegalArgumentException("The passing record is null");
 		}
 		
-		womanShopSalesIOManager.saveSalesRecord(database, record);
+		WomanShopSalesIOManager.getInstance().saveSalesRecord(record);
 		
 		//TODO: for debug
-		String[] results = womanShopSalesIOManager.searchAlldata(database);
+		String[] results = WomanShopSalesIOManager.getInstance().searchAlldata();
 		for (String result : results) {
 			Log.d("debug", "Sales:" + result);
 		}
 	}
 	
 	public ArrayList<SingleSalesRecord> restoreSingleSalesRecordsOfTheDay(Date date){
-		ArrayList<SingleSalesRecord> allSalesRecords = womanShopSalesIOManager.getSalesRecords();
+		ArrayList<SingleSalesRecord> allSalesRecords = WomanShopSalesIOManager.getInstance().getSalesRecords();
 		ArrayList<SingleSalesRecord> salesRecordsOfTheDay = new ArrayList<SingleSalesRecord>();
 		
 		for (SingleSalesRecord record : allSalesRecords) {
@@ -56,7 +51,7 @@ public class SalesRecordManager {
 	}
 	
 	public SingleSalesRecord getSingleSalesRecord(Date date){
-		ArrayList<SingleSalesRecord> allSalesRecords = womanShopSalesIOManager.getSalesRecords();
+		ArrayList<SingleSalesRecord> allSalesRecords = WomanShopSalesIOManager.getInstance().getSalesRecords();
 		
 		for (SingleSalesRecord record : allSalesRecords) {
 			if (areSameMinute(record.getSalesDate(), date)) {

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopIOManager.java
@@ -14,6 +14,7 @@ import com.ricoh.pos.data.WomanShopDataDef;
 
 public class WomanShopIOManager implements IOManager {
 
+	private SQLiteDatabase database;
 	private static String DATABASE_NAME = "products_dummy";
 
 	public WomanShopIOManager() {
@@ -34,7 +35,7 @@ public class WomanShopIOManager implements IOManager {
 	}
 
 	@Override
-	public void insertRecords(SQLiteDatabase database, BufferedReader bufferReader) {
+	public void insertRecords(BufferedReader bufferReader) {
 
 		ContentValues contentValue = new ContentValues();
 		try {
@@ -59,7 +60,7 @@ public class WomanShopIOManager implements IOManager {
 	}
 
 	@Override
-	public String[] searchAlldata(SQLiteDatabase database) {
+	public String[] searchAlldata() {
 		Cursor cursor = null;
 
 		try {
@@ -90,7 +91,7 @@ public class WomanShopIOManager implements IOManager {
 
 	// TODO: Temporary function
 	@Override
-	public String searchByCode(SQLiteDatabase database, String code) {
+	public String searchByCode(String code) {
 		Cursor cursor = null;
 		try {
 			cursor = database.query(
@@ -111,6 +112,22 @@ public class WomanShopIOManager implements IOManager {
 			if (cursor != null) {
 				cursor.close();
 			}
+		}
+	}
+	
+	// TODO: Add this function to interface
+	public void setDatabase(SQLiteDatabase database) {
+		if (this.database == null) {
+			Log.d("debug", "Database set:" + DATABASE_NAME);
+			this.database = database;
+		}
+	}
+	
+	// TODO: Add this function to interface
+	public void closeDatabase() {
+		if (database != null) {
+			Log.d("debug", "Database closed:" + DATABASE_NAME);
+			database.close();
 		}
 	}
 


### PR DESCRIPTION
salesDBに保存していたデータを、Syncボタンを押す事でCSVとして吐き出す実装をしました。
また、同じ商品名をsalesDBに登録できないバグも発生していたため、そちらの修正もあわせて行いました。

アプリを終了してもsalesDBは残っており、Syncボタンを押す事でそのDBとcsvのデータは完全に同じものになります。（Syncを押すたびにCSVを上書きするため、CSVの行数が増えていくような追記モードで書き込んでいません。）
