### PR TITLE
Implement importing and exporting data using internal SD

### DIFF
--- a/AndroidPOS/src/com/ricoh/pos/DataSyncTask.java
+++ b/AndroidPOS/src/com/ricoh/pos/DataSyncTask.java
@@ -4,12 +4,11 @@ import java.io.BufferedReader;
 
 import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.res.AssetManager;
 import android.os.AsyncTask;
 import android.util.Log;
 
-import com.ricoh.pos.model.IOManager;
 import com.ricoh.pos.model.ProductsManager;
+import com.ricoh.pos.model.WomanShopIOManager;
 import com.ricoh.pos.model.WomanShopSalesIOManager;
 
 public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String>> {
@@ -17,11 +16,11 @@ public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String
 	DataSyncTaskCallback callback;
 	Context context;
 	ProgressDialog progressDialog;
-	IOManager womanShopIOManager;
+	WomanShopIOManager womanShopIOManager;
 	ProductsManager productsManager;
 
 	public DataSyncTask(Context context, DataSyncTaskCallback callback,
-			IOManager womanShopIOManager) {
+			WomanShopIOManager womanShopIOManager) {
 		this.callback = callback;
 		this.context = context;
 		this.womanShopIOManager = womanShopIOManager;
@@ -46,8 +45,9 @@ public class DataSyncTask extends AsyncTask<String, Void, AsyncTaskResult<String
 		try {
 			Log.d("debug", "SyncButton click");
 
-			AssetManager assetManager = context.getResources().getAssets();
-			BufferedReader bufferReader = womanShopIOManager.importCSVfromAssets(assetManager);
+			//AssetManager assetManager = context.getResources().getAssets();
+			//BufferedReader bufferReader = womanShopIOManager.importCSVfromAssets(assetManager);
+			BufferedReader bufferReader = womanShopIOManager.importCSVfromSD();
 			if (bufferReader == null) {
 				Log.d("debug", "File not found");
 				return AsyncTaskResult.createErrorResult(R.string.sd_import_error);

--- a/AndroidPOS/src/com/ricoh/pos/MainMenuActivity.java
+++ b/AndroidPOS/src/com/ricoh/pos/MainMenuActivity.java
@@ -1,10 +1,5 @@
 package com.ricoh.pos;
 
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
@@ -87,14 +82,6 @@ public class MainMenuActivity extends Activity implements DataSyncTaskCallback {
 	public void onSuccessSyncData() {
 		Toast.makeText(this, R.string.sync_success, Toast.LENGTH_LONG).show();
 		setRegisterButtonEnabled();
-		
-		// TODO: For debug
-		try {
-			Log.d("debug", loadText("sales_dummy.csv"));
-		} catch (IOException e1) {
-			// TODO Auto-generated catch block
-			e1.printStackTrace();
-		}
 	}
 
 	@Override
@@ -108,21 +95,5 @@ public class MainMenuActivity extends Activity implements DataSyncTaskCallback {
 		} else {
 			findViewById(R.id.RegisterButton).setEnabled(false);
 		}
-	}
-	
-	// TODO For debug
-	private String loadText(String fileName) throws IOException {
-		FileInputStream input = this.openFileInput(fileName);
-		
-		BufferedReader reader = new BufferedReader(new InputStreamReader(input));
-		StringBuffer strBuffer = new StringBuffer();
-		String line;
-		while ((line = reader.readLine()) != null) {
-			strBuffer.append(line);
-			strBuffer.append("\n");
-		}
-		reader.close();
-		
-		return strBuffer.toString();
 	}
 }

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopIOManager.java
@@ -1,6 +1,9 @@
 package com.ricoh.pos.model;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
@@ -8,6 +11,7 @@ import android.content.ContentValues;
 import android.content.res.AssetManager;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.Environment;
 import android.util.Log;
 
 import com.ricoh.pos.data.WomanShopDataDef;
@@ -16,6 +20,7 @@ public class WomanShopIOManager implements IOManager {
 
 	private SQLiteDatabase database;
 	private static String DATABASE_NAME = "products_dummy";
+	private static String csvStorageFolder = "/AndroidPOS";
 
 	public WomanShopIOManager() {
 		// Nothing to do
@@ -115,6 +120,19 @@ public class WomanShopIOManager implements IOManager {
 		}
 	}
 	
+	public BufferedReader importCSVfromSD() {
+		BufferedReader bufferReader = null;
+		
+		try {
+			String csvStoragePath = getCSVStoragePath();
+			File productDataCSV = new File(csvStoragePath + "/products_dummy.csv");
+			bufferReader = new BufferedReader(new FileReader(productDataCSV));
+		} catch (FileNotFoundException e) {
+			System.out.println(e);
+		}
+		return bufferReader;
+	}
+	
 	// TODO: Add this function to interface
 	public void setDatabase(SQLiteDatabase database) {
 		if (this.database == null) {
@@ -170,5 +188,11 @@ public class WomanShopIOManager implements IOManager {
 					+ totalCostToEntrep + ":" + totalProfitToEntrep + ":" + "\n";
 		}
 		return result;
+	}
+	
+	private String getCSVStoragePath() {
+		File exterlStorage = Environment.getExternalStorageDirectory();
+		Log.d("debug", "Environment External:" + exterlStorage.getAbsolutePath());
+		return exterlStorage.getAbsolutePath() + csvStorageFolder;
 	}
 }

--- a/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
+++ b/AndroidPOS/src/com/ricoh/pos/model/WomanShopSalesIOManager.java
@@ -1,7 +1,8 @@
 package com.ricoh.pos.model;
 
 import java.io.BufferedReader;
-import java.io.FileOutputStream;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.os.Environment;
 import android.util.Log;
 
 import com.ricoh.pos.data.Order;
@@ -23,6 +25,7 @@ public class WomanShopSalesIOManager implements IOManager {
 	private SQLiteDatabase salesDatabase;
 	private static String DATABASE_NAME = "sales_dummy";
 	private ArrayList<SingleSalesRecord> salesRecords;
+	private static String csvStorageFolder = "/AndroidPOS";
 
 	private WomanShopSalesIOManager() {
 		this.salesRecords = new ArrayList<SingleSalesRecord>();
@@ -251,17 +254,36 @@ public class WomanShopSalesIOManager implements IOManager {
 	}
 	
 	private void writeSalesData(String[] salesData, Context context) {
+		String csvStoragePath = getCSVStoragePath();
+		File csvStorage = new File(csvStoragePath);
+		if (!csvStorage.exists()) {
+			Log.d("debug", "make directory:" + csvStoragePath);
+			csvStorage.mkdir();
+		}
+		File salesDataCSV = new File(csvStoragePath + "/sales_dummy.csv");
+		FileWriter filewriter = null;
 		try {
-			FileOutputStream outputStream = context.openFileOutput("sales_dummy.csv", Context.MODE_PRIVATE);
+			filewriter = new FileWriter(salesDataCSV);
 			for (String singleSalesData : salesData) {
 				Log.d("debug", "write csv:" + singleSalesData);
-				outputStream.write(singleSalesData.getBytes());
+				filewriter.write(singleSalesData);
 			}
-			outputStream.close();
 		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			System.out.println(e);
+		} finally {
+			if (filewriter != null) {
+				try {
+					filewriter.close();
+				} catch (IOException e) {
+					System.out.println(e);
+				}
+			}
 		}
 	}
-}
 
+	private String getCSVStoragePath() {
+		File exterlStorage = Environment.getExternalStorageDirectory();
+		Log.d("debug", "Environment External:" + exterlStorage.getAbsolutePath());
+		return exterlStorage.getAbsolutePath() + csvStorageFolder;
+	}
+}


### PR DESCRIPTION
内部SDに保存されている商品csvからデータをインポートし、同時に売り上げcsvをエクスポートする実装をしました。
私が実装した環境では、内部SDのパスは/mnt/sdcardとなっていますが、Android端末によって異なるようです。

その直下にAndroidPOSというフォルダを置いて、その中に商品csvを置けば正常に動作します。
（その他の実装用にDataSyncTask.javaの48,49行目をコメントアウトしていますので、従来通りAssetsから読み込みたい場合は、50行目をコメントアウトして切り替えてください。）
